### PR TITLE
Changed all assert method names to remove deprecated aliases

### DIFF
--- a/mox_test.py
+++ b/mox_test.py
@@ -66,13 +66,13 @@ class OrTest(unittest.TestCase):
 
   def testValidOr(self):
     """Or should be True if either Comparator returns True."""
-    self.assert_(mox.Or(mox.IsA(dict), mox.IsA(str)) == {})
-    self.assert_(mox.Or(mox.IsA(dict), mox.IsA(str)) == 'test')
-    self.assert_(mox.Or(mox.IsA(str), mox.IsA(str)) == 'test')
+    self.assertTrue(mox.Or(mox.IsA(dict), mox.IsA(str)) == {})
+    self.assertTrue(mox.Or(mox.IsA(dict), mox.IsA(str)) == 'test')
+    self.assertTrue(mox.Or(mox.IsA(str), mox.IsA(str)) == 'test')
 
   def testInvalidOr(self):
     """Or should be False if both Comparators return False."""
-    self.failIf(mox.Or(mox.IsA(dict), mox.IsA(str)) == 0)
+    self.assertFalse(mox.Or(mox.IsA(dict), mox.IsA(str)) == 0)
 
 
 class AndTest(unittest.TestCase):
@@ -80,12 +80,12 @@ class AndTest(unittest.TestCase):
 
   def testValidAnd(self):
     """And should be True if both Comparators return True."""
-    self.assert_(mox.And(mox.IsA(str), mox.IsA(str)) == '1')
+    self.assertTrue(mox.And(mox.IsA(str), mox.IsA(str)) == '1')
 
   def testClauseOneFails(self):
     """And should be False if the first Comparator returns False."""
 
-    self.failIf(mox.And(mox.IsA(dict), mox.IsA(str)) == '1')
+    self.assertFalse(mox.And(mox.IsA(dict), mox.IsA(str)) == '1')
 
   def testAdvancedUsage(self):
     """And should work with other Comparators.
@@ -93,13 +93,13 @@ class AndTest(unittest.TestCase):
     Note: this test is reliant on In and ContainsKeyValue.
     """
     test_dict = {"mock" : "obj", "testing" : "isCOOL"}
-    self.assert_(mox.And(mox.In("testing"),
+    self.assertTrue(mox.And(mox.In("testing"),
                            mox.ContainsKeyValue("mock", "obj")) == test_dict)
 
   def testAdvancedUsageFails(self):
     """Note: this test is reliant on In and ContainsKeyValue."""
     test_dict = {"mock" : "obj", "testing" : "isCOOL"}
-    self.failIf(mox.And(mox.In("NOTFOUND"),
+    self.assertFalse(mox.And(mox.In("NOTFOUND"),
                           mox.ContainsKeyValue("mock", "obj")) == test_dict)
 
 class FuncTest(unittest.TestCase):
@@ -110,13 +110,13 @@ class FuncTest(unittest.TestCase):
     equals_one = lambda x: x == 1
     always_none = lambda x: None
 
-    self.assert_(mox.Func(equals_one) == 1)
-    self.failIf(mox.Func(equals_one) == 0)
+    self.assertTrue(mox.Func(equals_one) == 1)
+    self.assertFalse(mox.Func(equals_one) == 0)
 
 
-    self.failIf(mox.Func(always_none) == 1)
-    self.failIf(mox.Func(always_none) == 0)
-    self.failIf(mox.Func(always_none) == None)
+    self.assertFalse(mox.Func(always_none) == 1)
+    self.assertFalse(mox.Func(always_none) == 0)
+    self.assertFalse(mox.Func(always_none) == None)
 
   def testFuncExceptionPropagation(self):
     """Exceptions within the validating function should propagate."""
@@ -129,7 +129,7 @@ class FuncTest(unittest.TestCase):
       else:
         return True
 
-    self.assert_(mox.Func(raiseExceptionOnNotOne) == 1)
+    self.assertTrue(mox.Func(raiseExceptionOnNotOne) == 1)
     self.assertRaises(TestException, mox.Func(raiseExceptionOnNotOne).__eq__, 2)
 
 class SameElementsAsTest(unittest.TestCase):
@@ -137,32 +137,32 @@ class SameElementsAsTest(unittest.TestCase):
 
   def testSortedLists(self):
     """Should return True if two lists are exactly equal."""
-    self.assert_(mox.SameElementsAs([1, 2.0, 'c']) == [1, 2.0, 'c'])
+    self.assertTrue(mox.SameElementsAs([1, 2.0, 'c']) == [1, 2.0, 'c'])
 
   def testUnsortedLists(self):
     """Should return True if two lists are unequal but have same elements."""
-    self.assert_(mox.SameElementsAs([1, 2.0, 'c']) == [2.0, 'c', 1])
+    self.assertTrue(mox.SameElementsAs([1, 2.0, 'c']) == [2.0, 'c', 1])
 
   def testUnhashableLists(self):
     """Should return True if two lists have the same unhashable elements."""
-    self.assert_(mox.SameElementsAs([{'a': 1}, {2: 'b'}]) ==
+    self.assertTrue(mox.SameElementsAs([{'a': 1}, {2: 'b'}]) ==
                  [{2: 'b'}, {'a': 1}])
 
   def testEmptyLists(self):
     """Should return True for two empty lists."""
-    self.assert_(mox.SameElementsAs([]) == [])
+    self.assertTrue(mox.SameElementsAs([]) == [])
 
   def testUnequalLists(self):
     """Should return False if the lists are not equal."""
-    self.failIf(mox.SameElementsAs([1, 2.0, 'c']) == [2.0, 'c'])
+    self.assertFalse(mox.SameElementsAs([1, 2.0, 'c']) == [2.0, 'c'])
 
   def testUnequalUnhashableLists(self):
     """Should return False if two lists with unhashable elements are unequal."""
-    self.failIf(mox.SameElementsAs([{'a': 1}, {2: 'b'}]) == [{2: 'b'}])
+    self.assertFalse(mox.SameElementsAs([{'a': 1}, {2: 'b'}]) == [{2: 'b'}])
 
   def testActualIsNotASequence(self):
     """Should return False if the actual object is not a sequence."""
-    self.failIf(mox.SameElementsAs([1]) == object())
+    self.assertFalse(mox.SameElementsAs([1]) == object())
 
   def testOneUnhashableObjectInActual(self):
     """Store the entire iterator for a correct comparison.
@@ -171,7 +171,7 @@ class SameElementsAsTest(unittest.TestCase):
     unhashable object was encountered and then was restarted, so the actual list
     appeared smaller than it was.
     """
-    self.failIf(mox.SameElementsAs([1, 2]) == iter([{}, 1, 2]))
+    self.assertFalse(mox.SameElementsAs([1, 2]) == iter([{}, 1, 2]))
 
 
 class ContainsKeyValueTest(unittest.TestCase):
@@ -180,15 +180,15 @@ class ContainsKeyValueTest(unittest.TestCase):
 
   def testValidPair(self):
     """Should return True if the key value is in the dict."""
-    self.assert_(mox.ContainsKeyValue("key", 1) == {"key": 1})
+    self.assertTrue(mox.ContainsKeyValue("key", 1) == {"key": 1})
 
   def testInvalidValue(self):
     """Should return False if the value is not correct."""
-    self.failIf(mox.ContainsKeyValue("key", 1) == {"key": 2})
+    self.assertFalse(mox.ContainsKeyValue("key", 1) == {"key": 2})
 
   def testInvalidKey(self):
     """Should return False if they key is not in the dict."""
-    self.failIf(mox.ContainsKeyValue("qux", 1) == {"key": 2})
+    self.assertFalse(mox.ContainsKeyValue("qux", 1) == {"key": 2})
 
 
 class ContainsAttributeValueTest(unittest.TestCase):
@@ -206,15 +206,15 @@ class ContainsAttributeValueTest(unittest.TestCase):
 
   def testValidPair(self):
     """Should return True if the object has the key attribute and it matches."""
-    self.assert_(mox.ContainsAttributeValue("key", 1) == self.test_object)
+    self.assertTrue(mox.ContainsAttributeValue("key", 1) == self.test_object)
 
   def testInvalidValue(self):
     """Should return False if the value is not correct."""
-    self.failIf(mox.ContainsKeyValue("key", 2) == self.test_object)
+    self.assertFalse(mox.ContainsKeyValue("key", 2) == self.test_object)
 
   def testInvalidKey(self):
     """Should return False if they the object doesn't have the property."""
-    self.failIf(mox.ContainsKeyValue("qux", 1) == self.test_object)
+    self.assertFalse(mox.ContainsKeyValue("qux", 1) == self.test_object)
 
 
 class InTest(unittest.TestCase):
@@ -222,24 +222,24 @@ class InTest(unittest.TestCase):
 
   def testItemInList(self):
     """Should return True if the item is in the list."""
-    self.assert_(mox.In(1) == [1, 2, 3])
+    self.assertTrue(mox.In(1) == [1, 2, 3])
 
   def testKeyInDict(self):
     """Should return True if the item is a key in a dict."""
-    self.assert_(mox.In("test") == {"test" : "module"})
+    self.assertTrue(mox.In("test") == {"test" : "module"})
 
   def testItemInTuple(self):
     """Should return True if the item is in the list."""
-    self.assert_(mox.In(1) == (1, 2, 3))
+    self.assertTrue(mox.In(1) == (1, 2, 3))
 
   def testTupleInTupleOfTuples(self):
-    self.assert_(mox.In((1, 2, 3)) == ((1, 2, 3), (1, 2)))
+    self.assertTrue(mox.In((1, 2, 3)) == ((1, 2, 3), (1, 2)))
 
   def testItemNotInList(self):
-    self.failIf(mox.In(1) == [2, 3])
+    self.assertFalse(mox.In(1) == [2, 3])
 
   def testTupleNotInTupleOfTuples(self):
-    self.failIf(mox.In((1, 2)) == ((1, 2, 3), (4, 5)))
+    self.assertFalse(mox.In((1, 2)) == ((1, 2, 3), (4, 5)))
 
 
 class NotTest(unittest.TestCase):
@@ -247,15 +247,15 @@ class NotTest(unittest.TestCase):
 
   def testItemInList(self):
     """Should return True if the item is NOT in the list."""
-    self.assert_(mox.Not(mox.In(42)) == [1, 2, 3])
+    self.assertTrue(mox.Not(mox.In(42)) == [1, 2, 3])
 
   def testKeyInDict(self):
     """Should return True if the item is NOT a key in a dict."""
-    self.assert_(mox.Not(mox.In("foo")) == {"key" : 42})
+    self.assertTrue(mox.Not(mox.In("foo")) == {"key" : 42})
 
   def testInvalidKeyWithNot(self):
     """Should return False if they key is NOT in the dict."""
-    self.assert_(mox.Not(mox.ContainsKeyValue("qux", 1)) == {"key": 2})
+    self.assertTrue(mox.Not(mox.ContainsKeyValue("qux", 1)) == {"key": 2})
 
 
 class StrContainsTest(unittest.TestCase):
@@ -264,23 +264,23 @@ class StrContainsTest(unittest.TestCase):
 
   def testValidSubstringAtStart(self):
     """Should return True if the substring is at the start of the string."""
-    self.assert_(mox.StrContains("hello") == "hello world")
+    self.assertTrue(mox.StrContains("hello") == "hello world")
 
   def testValidSubstringInMiddle(self):
     """Should return True if the substring is in the middle of the string."""
-    self.assert_(mox.StrContains("lo wo") == "hello world")
+    self.assertTrue(mox.StrContains("lo wo") == "hello world")
 
   def testValidSubstringAtEnd(self):
     """Should return True if the substring is at the end of the string."""
-    self.assert_(mox.StrContains("ld") == "hello world")
+    self.assertTrue(mox.StrContains("ld") == "hello world")
 
   def testInvaildSubstring(self):
     """Should return False if the substring is not in the string."""
-    self.failIf(mox.StrContains("AAA") == "hello world")
+    self.assertFalse(mox.StrContains("AAA") == "hello world")
 
   def testMultipleMatches(self):
     """Should return True if there are multiple occurances of substring."""
-    self.assert_(mox.StrContains("abc") == "ababcabcabcababc")
+    self.assertTrue(mox.StrContains("abc") == "ababcabcabcababc")
 
 
 class RegexTest(unittest.TestCase):
@@ -295,23 +295,23 @@ class RegexTest(unittest.TestCase):
 
     This ensures that re.search is used (instead of re.find).
     """
-    self.assert_(mox.Regex(r"a\s+b") == "x y z a b c")
+    self.assertTrue(mox.Regex(r"a\s+b") == "x y z a b c")
 
   def testNonMatchPattern(self):
     """Should return False if the pattern does not match the string."""
-    self.failIf(mox.Regex(r"a\s+b") == "x y z")
+    self.assertFalse(mox.Regex(r"a\s+b") == "x y z")
 
   def testFlagsPassedCorrectly(self):
     """Should return True as we pass IGNORECASE flag."""
-    self.assert_(mox.Regex(r"A", re.IGNORECASE) == "a")
+    self.assertTrue(mox.Regex(r"A", re.IGNORECASE) == "a")
 
   def testReprWithoutFlags(self):
     """repr should return the regular expression pattern."""
-    self.assert_(repr(mox.Regex(r"a\s+b")) == "<regular expression 'a\s+b'>")
+    self.assertTrue(repr(mox.Regex(r"a\s+b")) == "<regular expression 'a\s+b'>")
 
   def testReprWithFlags(self):
     """repr should return the regular expression pattern and flags."""
-    self.assert_(repr(mox.Regex(r"a\s+b", flags=4)) ==
+    self.assertTrue(repr(mox.Regex(r"a\s+b", flags=4)) ==
                  "<regular expression 'a\s+b', flags=4>")
 
 
@@ -366,37 +366,37 @@ class IsATest(unittest.TestCase):
 
   def testEqualityValid(self):
     """Verify that == correctly identifies objects of the same type."""
-    self.assert_(mox.IsA(str) == 'test')
+    self.assertTrue(mox.IsA(str) == 'test')
 
   def testEqualityInvalid(self):
     """Verify that == correctly identifies objects of different types."""
-    self.failIf(mox.IsA(str) == 10)
+    self.assertFalse(mox.IsA(str) == 10)
 
   def testInequalityValid(self):
     """Verify that != identifies objects of different type."""
-    self.assert_(mox.IsA(str) != 10)
+    self.assertTrue(mox.IsA(str) != 10)
 
   def testInequalityInvalid(self):
     """Verify that != correctly identifies objects of the same type."""
-    self.failIf(mox.IsA(str) != "test")
+    self.assertFalse(mox.IsA(str) != "test")
 
   def testEqualityInListValid(self):
     """Verify list contents are properly compared."""
     isa_list = [mox.IsA(str), mox.IsA(str)]
     str_list = ["abc", "def"]
-    self.assert_(isa_list == str_list)
+    self.assertTrue(isa_list == str_list)
 
   def testEquailtyInListInvalid(self):
     """Verify list contents are properly compared."""
     isa_list = [mox.IsA(str),mox.IsA(str)]
     mixed_list = ["abc", 123]
-    self.failIf(isa_list == mixed_list)
+    self.assertFalse(isa_list == mixed_list)
 
   def testSpecialTypes(self):
     """Verify that IsA can handle objects like StringIO."""
     isA = mox.IsA(StringIO())
     stringIO = StringIO()
-    self.assert_(isA == stringIO)
+    self.assertTrue(isA == stringIO)
 
 
 class IsAlmostTest(unittest.TestCase):
@@ -404,23 +404,23 @@ class IsAlmostTest(unittest.TestCase):
 
   def testEqualityValid(self):
     """Verify that == correctly identifies nearly equivalent floats."""
-    self.assertEquals(mox.IsAlmost(1.8999999999), 1.9)
+    self.assertEqual(mox.IsAlmost(1.8999999999), 1.9)
 
   def testEqualityInvalid(self):
     """Verify that == correctly identifies non-equivalent floats."""
-    self.assertNotEquals(mox.IsAlmost(1.899), 1.9)
+    self.assertNotEqual(mox.IsAlmost(1.899), 1.9)
 
   def testEqualityWithPlaces(self):
     """Verify that specifying places has the desired effect."""
-    self.assertNotEquals(mox.IsAlmost(1.899), 1.9)
-    self.assertEquals(mox.IsAlmost(1.899, places=2), 1.9)
+    self.assertNotEqual(mox.IsAlmost(1.899), 1.9)
+    self.assertEqual(mox.IsAlmost(1.899, places=2), 1.9)
 
   def testNonNumericTypes(self):
     """Verify that IsAlmost handles non-numeric types properly."""
 
-    self.assertNotEquals(mox.IsAlmost(1.8999999999), '1.9')
-    self.assertNotEquals(mox.IsAlmost('1.8999999999'), 1.9)
-    self.assertNotEquals(mox.IsAlmost('1.8999999999'), '1.9')
+    self.assertNotEqual(mox.IsAlmost(1.8999999999), '1.9')
+    self.assertNotEqual(mox.IsAlmost('1.8999999999'), 1.9)
+    self.assertNotEqual(mox.IsAlmost('1.8999999999'), '1.9')
 
 
 class ValueRememberTest(unittest.TestCase):
@@ -430,28 +430,28 @@ class ValueRememberTest(unittest.TestCase):
     """Verify that value will compare to stored value."""
     value = mox.Value()
     value.store_value('hello world')
-    self.assertEquals(value, 'hello world')
+    self.assertEqual(value, 'hello world')
 
   def testNoValue(self):
     """Verify that uninitialized value does not compare to "empty" values."""
     value = mox.Value()
-    self.assertNotEquals(value, None)
-    self.assertNotEquals(value, False)
-    self.assertNotEquals(value, 0)
-    self.assertNotEquals(value, '')
-    self.assertNotEquals(value, ())
-    self.assertNotEquals(value, [])
-    self.assertNotEquals(value, {})
-    self.assertNotEquals(value, object())
-    self.assertNotEquals(value, set())
+    self.assertNotEqual(value, None)
+    self.assertNotEqual(value, False)
+    self.assertNotEqual(value, 0)
+    self.assertNotEqual(value, '')
+    self.assertNotEqual(value, ())
+    self.assertNotEqual(value, [])
+    self.assertNotEqual(value, {})
+    self.assertNotEqual(value, object())
+    self.assertNotEqual(value, set())
 
   def testRememberValue(self):
     """Verify that comparing against remember will store argument."""
     value = mox.Value()
     remember = mox.Remember(value)
-    self.assertNotEquals(value, 'hello world')  # value not yet stored.
-    self.assertEquals(remember, 'hello world')  # store value here.
-    self.assertEquals(value, 'hello world')     # compare against stored value.
+    self.assertNotEqual(value, 'hello world')  # value not yet stored.
+    self.assertEqual(remember, 'hello world')  # store value here.
+    self.assertEqual(value, 'hello world')     # compare against stored value.
 
 
 class MockMethodTest(unittest.TestCase):
@@ -465,19 +465,19 @@ class MockMethodTest(unittest.TestCase):
 
   def testNameAttribute(self):
     """Should provide a __name__ attribute."""
-    self.assertEquals('testMethod', self.mock_method.__name__)
+    self.assertEqual('testMethod', self.mock_method.__name__)
 
   def testAndReturnNoneByDefault(self):
     """Should return None by default."""
     return_value = self.mock_method(['original'])
-    self.assert_(return_value == None)
+    self.assertTrue(return_value == None)
 
   def testAndReturnValue(self):
     """Should return a specificed return value."""
     expected_return_value = "test"
     self.expected_method.AndReturn(expected_return_value)
     return_value = self.mock_method(['original'])
-    self.assert_(return_value == expected_return_value)
+    self.assertTrue(return_value == expected_return_value)
 
   def testAndRaiseException(self):
     """Should raise a specified exception."""
@@ -493,7 +493,7 @@ class MockMethodTest(unittest.TestCase):
       mutable_list[0] = 'mutation'
     self.expected_method.WithSideEffects(modifier).AndReturn(1)
     self.mock_method(local_list)
-    self.assertEquals('mutation', local_list[0])
+    self.assertEqual('mutation', local_list[0])
 
   def testWithReturningSideEffects(self):
     """Should call state modifier and propagate its return value."""
@@ -505,8 +505,8 @@ class MockMethodTest(unittest.TestCase):
       return expected_return
     self.expected_method.WithSideEffects(modifier_with_return)
     actual_return = self.mock_method(local_list)
-    self.assertEquals('mutation', local_list[0])
-    self.assertEquals(expected_return, actual_return)
+    self.assertEqual('mutation', local_list[0])
+    self.assertEqual(expected_return, actual_return)
 
   def testWithReturningSideEffectsWithAndReturn(self):
     """Should call state modifier and ignore its return value."""
@@ -520,8 +520,8 @@ class MockMethodTest(unittest.TestCase):
     self.expected_method.WithSideEffects(modifier_with_return).AndReturn(
         expected_return)
     actual_return = self.mock_method(local_list)
-    self.assertEquals('mutation', local_list[0])
-    self.assertEquals(expected_return, actual_return)
+    self.assertEqual('mutation', local_list[0])
+    self.assertEqual(expected_return, actual_return)
 
   def testEqualityNoParamsEqual(self):
     """Methods with the same name and without params should be equal."""
@@ -531,7 +531,7 @@ class MockMethodTest(unittest.TestCase):
   def testEqualityNoParamsNotEqual(self):
     """Methods with different names and without params should not be equal."""
     expected_method = mox.MockMethod("otherMethod", [], [], False)
-    self.failIfEqual(self.mock_method, expected_method)
+    self.assertNotEqual(self.mock_method, expected_method)
 
   def testEqualityParamsEqual(self):
     """Methods with the same name and parameters should be equal."""
@@ -548,7 +548,7 @@ class MockMethodTest(unittest.TestCase):
     expected_method._params = [1, 2, 3]
 
     self.mock_method._params = ['a', 'b', 'c']
-    self.failIfEqual(self.mock_method, expected_method)
+    self.assertNotEqual(self.mock_method, expected_method)
 
   def testEqualityNamedParamsEqual(self):
     """Methods with the same name and same named params should be equal."""
@@ -565,11 +565,11 @@ class MockMethodTest(unittest.TestCase):
     expected_method._named_params = {"input1": "test", "input2": "params"}
 
     self.mock_method._named_params = {"input1": "test2", "input2": "params2"}
-    self.failIfEqual(self.mock_method, expected_method)
+    self.assertNotEqual(self.mock_method, expected_method)
 
   def testEqualityWrongType(self):
     """Method should not be equal to an object of a different type."""
-    self.failIfEqual(self.mock_method, "string?")
+    self.assertNotEqual(self.mock_method, "string?")
 
   def testObjectEquality(self):
     """Equality of objects should work without a Comparator"""
@@ -629,12 +629,12 @@ class MockAnythingTest(unittest.TestCase):
     self.mock_object._Replay()
     actual = str(self.mock_object)
     self.mock_object._Verify();
-    self.assertEquals("foo", actual)
+    self.assertEqual("foo", actual)
 
   def testSetupMode(self):
     """Verify the mock will accept any call."""
     self.mock_object.NonsenseCall()
-    self.assert_(len(self.mock_object._expected_calls_queue) == 1)
+    self.assertTrue(len(self.mock_object._expected_calls_queue) == 1)
 
   def testReplayWithExpectedCall(self):
     """Verify the mock replays method calls as expected."""
@@ -668,7 +668,7 @@ class MockAnythingTest(unittest.TestCase):
     self.mock_object[1].AndReturn(True)
     self.mock_object._Replay()
     returned_val = self.mock_object[1]
-    self.assert_(returned_val)
+    self.assertTrue(returned_val)
     self.mock_object._Verify()
 
   def testNonzero(self):
@@ -689,18 +689,18 @@ class MockAnythingTest(unittest.TestCase):
   def testEquals(self):
     """A mock should be able to compare itself to another object."""
     self.mock_object._Replay()
-    self.assertEquals(self.mock_object, self.mock_object)
+    self.assertEqual(self.mock_object, self.mock_object)
 
   def testEqualsMockFailure(self):
     """Verify equals identifies unequal objects."""
     self.mock_object.SillyCall()
     self.mock_object._Replay()
-    self.assertNotEquals(self.mock_object, mox.MockAnything())
+    self.assertNotEqual(self.mock_object, mox.MockAnything())
 
   def testEqualsInstanceFailure(self):
     """Verify equals identifies that objects are different instances."""
     self.mock_object._Replay()
-    self.assertNotEquals(self.mock_object, TestClass())
+    self.assertNotEqual(self.mock_object, TestClass())
 
   def testNotEquals(self):
     """Verify not equals works."""
@@ -735,13 +735,13 @@ class MockAnythingTest(unittest.TestCase):
     self.mock_object().AndReturn('mox0rd')
     self.mock_object._Replay()
 
-    self.assertEquals('mox0rd', self.mock_object())
+    self.assertEqual('mox0rd', self.mock_object())
 
     self.mock_object._Verify()
 
   def testIsReprable(self):
     """Test that MockAnythings can be repr'd without causing a failure."""
-    self.failUnless('MockAnything' in repr(self.mock_object))
+    self.assertTrue('MockAnything' in repr(self.mock_object))
 
 
 class MethodCheckerTest(unittest.TestCase):
@@ -891,7 +891,7 @@ class MockObjectTest(unittest.TestCase):
   def testSetupModeWithValidCall(self):
     """Verify the mock object properly mocks a basic method call."""
     self.mock_object.ValidCall()
-    self.assert_(len(self.mock_object._expected_calls_queue) == 1)
+    self.assertTrue(len(self.mock_object._expected_calls_queue) == 1)
 
   def testSetupModeWithInvalidCall(self):
     """UnknownMethodCallError should be raised if a non-member method is called.
@@ -923,47 +923,47 @@ class MockObjectTest(unittest.TestCase):
 
   def testIsInstance(self):
     """Mock should be able to pass as an instance of the mocked class."""
-    self.assert_(isinstance(self.mock_object, TestClass))
+    self.assertTrue(isinstance(self.mock_object, TestClass))
 
   def testFindValidMethods(self):
     """Mock should be able to mock all public methods."""
-    self.assert_('ValidCall' in self.mock_object._known_methods)
-    self.assert_('OtherValidCall' in self.mock_object._known_methods)
-    self.assert_('MyClassMethod' in self.mock_object._known_methods)
-    self.assert_('MyStaticMethod' in self.mock_object._known_methods)
-    self.assert_('_ProtectedCall' in self.mock_object._known_methods)
-    self.assert_('__PrivateCall' not in self.mock_object._known_methods)
-    self.assert_('_TestClass__PrivateCall' in self.mock_object._known_methods)
+    self.assertTrue('ValidCall' in self.mock_object._known_methods)
+    self.assertTrue('OtherValidCall' in self.mock_object._known_methods)
+    self.assertTrue('MyClassMethod' in self.mock_object._known_methods)
+    self.assertTrue('MyStaticMethod' in self.mock_object._known_methods)
+    self.assertTrue('_ProtectedCall' in self.mock_object._known_methods)
+    self.assertTrue('__PrivateCall' not in self.mock_object._known_methods)
+    self.assertTrue('_TestClass__PrivateCall' in self.mock_object._known_methods)
 
   def testFindsSuperclassMethods(self):
     """Mock should be able to mock superclasses methods."""
     self.mock_object = mox.MockObject(ChildClass)
-    self.assert_('ValidCall' in self.mock_object._known_methods)
-    self.assert_('OtherValidCall' in self.mock_object._known_methods)
-    self.assert_('MyClassMethod' in self.mock_object._known_methods)
-    self.assert_('ChildValidCall' in self.mock_object._known_methods)
+    self.assertTrue('ValidCall' in self.mock_object._known_methods)
+    self.assertTrue('OtherValidCall' in self.mock_object._known_methods)
+    self.assertTrue('MyClassMethod' in self.mock_object._known_methods)
+    self.assertTrue('ChildValidCall' in self.mock_object._known_methods)
 
   def testAccessClassVariables(self):
     """Class variables should be accessible through the mock."""
-    self.assert_('SOME_CLASS_VAR' in self.mock_object._known_vars)
-    self.assert_('_PROTECTED_CLASS_VAR' in self.mock_object._known_vars)
-    self.assertEquals('test_value', self.mock_object.SOME_CLASS_VAR)
+    self.assertTrue('SOME_CLASS_VAR' in self.mock_object._known_vars)
+    self.assertTrue('_PROTECTED_CLASS_VAR' in self.mock_object._known_vars)
+    self.assertEqual('test_value', self.mock_object.SOME_CLASS_VAR)
 
   def testEquals(self):
     """A mock should be able to compare itself to another object."""
     self.mock_object._Replay()
-    self.assertEquals(self.mock_object, self.mock_object)
+    self.assertEqual(self.mock_object, self.mock_object)
 
   def testEqualsMockFailure(self):
     """Verify equals identifies unequal objects."""
     self.mock_object.ValidCall()
     self.mock_object._Replay()
-    self.assertNotEquals(self.mock_object, mox.MockObject(TestClass))
+    self.assertNotEqual(self.mock_object, mox.MockObject(TestClass))
 
   def testEqualsInstanceFailure(self):
     """Verify equals identifies that objects are different instances."""
     self.mock_object._Replay()
-    self.assertNotEquals(self.mock_object, TestClass())
+    self.assertNotEqual(self.mock_object, TestClass())
 
   def testNotEquals(self):
     """Verify not equals works."""
@@ -1115,7 +1115,7 @@ class MockObjectTest(unittest.TestCase):
     dummy[1].AndReturn('3')
 
     dummy._Replay()
-    self.assertEquals('3', dummy.__getitem__(1))
+    self.assertEqual('3', dummy.__getitem__(1))
     dummy._Verify()
 
   def testMockIter_ExpectedIter_Success(self):
@@ -1142,7 +1142,7 @@ class MockObjectTest(unittest.TestCase):
 
     dummy._Replay()
 
-    self.failUnless('X' in dummy)
+    self.assertTrue('X' in dummy)
 
     dummy._Verify()
 
@@ -1205,7 +1205,7 @@ class MockObjectTest(unittest.TestCase):
     dummy[2].AndRaise(IndexError)
 
     dummy._Replay()
-    self.assertEquals(['a', 'b'], [x for x in dummy])
+    self.assertEqual(['a', 'b'], [x for x in dummy])
     dummy._Verify()
 
   def testMockIter_ExpectedNoGetItem_NoSuccess(self):
@@ -1228,12 +1228,12 @@ class MockObjectTest(unittest.TestCase):
     dummy = mox.MockObject(TestSubClass)
     iter(dummy).AndReturn(iter(['a', 'b']))
     dummy._Replay()
-    self.assertEquals(['a', 'b'], [x for x in dummy])
+    self.assertEqual(['a', 'b'], [x for x in dummy])
     dummy._Verify()
 
   def testInstantiationWithAdditionalAttributes(self):
     mock_object = mox.MockObject(TestClass, attrs={"attr1": "value"})
-    self.assertEquals(mock_object.attr1, "value")
+    self.assertEqual(mock_object.attr1, "value")
 
   def testCantOverrideMethodsWithAttributes(self):
     self.assertRaises(ValueError, mox.MockObject, TestClass,
@@ -1292,7 +1292,7 @@ class MoxTest(unittest.TestCase):
     self.mox.ReplayAll()
 
     ret_val = mock_obj.ValidCall()
-    self.assertEquals("yes", ret_val)
+    self.assertEqual("yes", ret_val)
     self.mox.VerifyAll()
 
   def testSignatureMatchingWithComparatorAsFirstArg(self):
@@ -1323,7 +1323,7 @@ class MoxTest(unittest.TestCase):
     self.mox.ReplayAll()
 
     ret_val = mock_obj("foo")
-    self.assertEquals("qux", ret_val)
+    self.assertEqual("qux", ret_val)
     self.mox.VerifyAll()
 
   def testInheritedCallableObject(self):
@@ -1333,7 +1333,7 @@ class MoxTest(unittest.TestCase):
     self.mox.ReplayAll()
 
     ret_val = mock_obj("foo")
-    self.assertEquals("qux", ret_val)
+    self.assertEqual("qux", ret_val)
     self.mox.VerifyAll()
 
   def testCallOnNonCallableObject(self):
@@ -1424,8 +1424,8 @@ class MoxTest(unittest.TestCase):
     actual_one = mock_obj.Method(1)
     mock_obj.Close()
 
-    self.assertEquals(9, actual_one)
-    self.assertEquals(10, actual_two)
+    self.assertEqual(9, actual_one)
+    self.assertEqual(10, actual_two)
 
     self.mox.VerifyAll()
 
@@ -1470,10 +1470,10 @@ class MoxTest(unittest.TestCase):
 
     self.mox.VerifyAll()
 
-    self.assertEquals(9, actual_one)
-    self.assertEquals(9, second_one) # Repeated calls should return same number.
-    self.assertEquals(10, actual_two)
-    self.assertEquals(42, actual_three)
+    self.assertEqual(9, actual_one)
+    self.assertEqual(9, second_one) # Repeated calls should return same number.
+    self.assertEqual(10, actual_two)
+    self.assertEqual(42, actual_three)
 
   def testMultipleTimesUsingIsAParameter(self):
     """Test if MultipleTimesGroup works with a IsA parameter."""
@@ -1490,8 +1490,8 @@ class MoxTest(unittest.TestCase):
 
     self.mox.VerifyAll()
 
-    self.assertEquals(9, actual_one)
-    self.assertEquals(9, second_one) # Repeated calls should return same number.
+    self.assertEqual(9, actual_one)
+    self.assertEqual(9, second_one) # Repeated calls should return same number.
 
   def testMutlipleTimesUsingFunc(self):
     """Test that the Func is not evaluated more times than necessary.
@@ -1520,7 +1520,7 @@ class MoxTest(unittest.TestCase):
 
     self.mox.VerifyAll()
 
-    self.assertEquals(2, self.counter)
+    self.assertEqual(2, self.counter)
 
   def testMultipleTimesThreeMethods(self):
     """Test if MultipleTimesGroup works with three or more methods."""
@@ -1542,10 +1542,10 @@ class MoxTest(unittest.TestCase):
     actual_four = mock_obj.Method(4)
     mock_obj.Close()
 
-    self.assertEquals(9, actual_one)
-    self.assertEquals(8, actual_two)
-    self.assertEquals(7, actual_three)
-    self.assertEquals(10, actual_four)
+    self.assertEqual(9, actual_one)
+    self.assertEqual(8, actual_two)
+    self.assertEqual(7, actual_three)
+    self.assertEqual(10, actual_four)
 
     self.mox.VerifyAll()
 
@@ -1587,8 +1587,8 @@ class MoxTest(unittest.TestCase):
     mock_obj.Method(3)
     mock_obj.Close()
 
-    self.assertEquals(9, actual_one)
-    self.assertEquals(42, actual_three)
+    self.assertEqual(9, actual_one)
+    self.assertEqual(42, actual_three)
 
     self.mox.VerifyAll()
 
@@ -1636,7 +1636,7 @@ class MoxTest(unittest.TestCase):
     self.mox.ReplayAll()
 
     local_list = ['original']
-    self.failUnlessRaises(Exception,
+    self.assertRaises(Exception,
                           mock_obj.ConfigureInOutParameter,
                           local_list)
     mock_obj.WorkWithParameter(local_list)
@@ -1659,7 +1659,7 @@ class MoxTest(unittest.TestCase):
 
     self.mox.VerifyAll()
     self.mox.UnsetStubs()
-    self.assertEquals('foo', actual)
+    self.assertEqual('foo', actual)
     self.assertTrue(type(test_obj.OtherValidCall) is method_type)
 
   def testStubOutMethod_Unbound_Comparator(self):
@@ -1673,7 +1673,7 @@ class MoxTest(unittest.TestCase):
 
     self.mox.VerifyAll()
     self.mox.UnsetStubs()
-    self.assertEquals('foo', actual)
+    self.assertEqual('foo', actual)
 
   def testStubOutMethod_Unbound_Subclass_Comparator(self):
     self.mox.StubOutWithMock(mox_test_helper.TestClassFromAnotherModule,
@@ -1687,7 +1687,7 @@ class MoxTest(unittest.TestCase):
 
     self.mox.VerifyAll()
     self.mox.UnsetStubs()
-    self.assertEquals('foo', actual)
+    self.assertEqual('foo', actual)
 
   def testStubOuMethod_Unbound_WithOptionalParams(self):
     self.mox = mox.Mox()
@@ -1712,7 +1712,7 @@ class MoxTest(unittest.TestCase):
 
     self.mox.VerifyAll()
     self.mox.UnsetStubs()
-    self.assertEquals('foo', actual)
+    self.assertEqual('foo', actual)
 
   def testStubOutMethod_Unbound_DifferentInstance(self):
     instance = TestClass()
@@ -1773,7 +1773,7 @@ class MoxTest(unittest.TestCase):
 
     self.mox.VerifyAll()
     self.mox.UnsetStubs()
-    self.assertEquals('foo', actual)
+    self.assertEqual('foo', actual)
 
   def testStubOutMethod_Bound_NamedUsingPositional(self):
     """Check positional parameters can be matched to keyword arguments."""
@@ -1852,7 +1852,7 @@ class MoxTest(unittest.TestCase):
   def testStubOutClass_OldStyle(self):
     """Test a mocked class whose __init__ returns a Mock."""
     self.mox.StubOutWithMock(mox_test_helper, 'TestClassFromAnotherModule')
-    self.assert_(isinstance(mox_test_helper.TestClassFromAnotherModule,
+    self.assertTrue(isinstance(mox_test_helper.TestClassFromAnotherModule,
                             mox.MockObject))
 
     mock_instance = self.mox.CreateMock(
@@ -1867,7 +1867,7 @@ class MoxTest(unittest.TestCase):
 
     self.mox.VerifyAll()
     self.mox.UnsetStubs()
-    self.assertEquals('mock instance', actual)
+    self.assertEqual('mock instance', actual)
 
   def testStubOutClass(self):
     self.mox.StubOutClassWithMocks(mox_test_helper, 'CallableClass')
@@ -1892,12 +1892,12 @@ class MoxTest(unittest.TestCase):
     self.mox.UnsetStubs()
 
     # Verify the correct mocks were returned
-    self.assertEquals(mock_one, one)
-    self.assertEquals(mock_two, two)
+    self.assertEqual(mock_one, one)
+    self.assertEqual(mock_two, two)
 
     # Verify
-    self.assertEquals('mock', actual_one)
-    self.assertEquals('called mock', actual_two)
+    self.assertEqual('mock', actual_one)
+    self.assertEqual('called mock', actual_two)
 
   try:
     import abc
@@ -1923,12 +1923,12 @@ class MoxTest(unittest.TestCase):
       self.mox.UnsetStubs()
 
       # Verify the correct mocks were returned
-      self.assertEquals(mock_foo, foo)
-      self.assertEquals(mock_spam, spam)
+      self.assertEqual(mock_foo, foo)
+      self.assertEqual(mock_spam, spam)
 
       # Verify
-      self.assertEquals('mock bar', actual_foo_bar)
-      self.assertEquals('called mock', actual_spam)
+      self.assertEqual('mock bar', actual_foo_bar)
+      self.assertEqual('called mock', actual_spam)
   except ImportError:
     print >>sys.stderr, "testStubOutClass_ABCMeta. ... Skipped - no abc module"
 
@@ -2024,7 +2024,7 @@ class MoxTest(unittest.TestCase):
 
     foo = Foo()
     self.mox.StubOutWithMock(foo, "obj")
-    self.assert_(isinstance(foo.obj, mox.MockObject))
+    self.assertTrue(isinstance(foo.obj, mox.MockObject))
     foo.obj.ValidCall()
     self.mox.ReplayAll()
 
@@ -2032,7 +2032,7 @@ class MoxTest(unittest.TestCase):
 
     self.mox.VerifyAll()
     self.mox.UnsetStubs()
-    self.failIf(isinstance(foo.obj, mox.MockObject))
+    self.assertFalse(isinstance(foo.obj, mox.MockObject))
 
   def testForgotReplayHelpfulMessage(self):
     """If there is an AttributeError on a MockMethod, give users a helpful msg.
@@ -2045,7 +2045,7 @@ class MoxTest(unittest.TestCase):
     try:
       foo.GetBar().ShowMeTheMoney()
     except AttributeError as e:
-      self.assertEquals('MockMethod has no attribute "ShowMeTheMoney". '
+      self.assertEqual('MockMethod has no attribute "ShowMeTheMoney". '
           'Did you remember to put your mocks in replay mode?', str(e))
 
   def testSwallowedUnknownMethodCall(self):
@@ -2258,14 +2258,14 @@ class MoxTestBaseTest(unittest.TestCase):
     self.test_stubs.SmartUnsetAll()
     self.mox.ReplayAll()
     self.test.run(result=self.result)
-    self.failIf(self.result.wasSuccessful())
+    self.assertFalse(self.result.wasSuccessful())
     self.mox.VerifyAll()
 
   def testExpectedNotCalledNoMocks(self):
     """Let testExpectedNotCalled() unset all the mocks by itself."""
     self._CreateTest('testExpectedNotCalled')
     self.test.run(result=self.result)
-    self.failIf(self.result.wasSuccessful())
+    self.assertFalse(self.result.wasSuccessful())
     self.assertEqual(OS_LISTDIR, mox_test_helper.os.listdir)
 
   def testUnexpectedCall(self):
@@ -2281,7 +2281,7 @@ class MoxTestBaseTest(unittest.TestCase):
     self.test_stubs.SmartUnsetAll()
     self.mox.ReplayAll()
     self.test.run(result=self.result)
-    self.failIf(self.result.wasSuccessful())
+    self.assertFalse(self.result.wasSuccessful())
     self.mox.VerifyAll()
 
   def testFailure(self):
@@ -2297,7 +2297,7 @@ class MoxTestBaseTest(unittest.TestCase):
     self.test_stubs.SmartUnsetAll()
     self.mox.ReplayAll()
     self.test.run(result=self.result)
-    self.failIf(self.result.wasSuccessful())
+    self.assertFalse(self.result.wasSuccessful())
     self.mox.VerifyAll()
 
   def testMixin(self):
@@ -2339,11 +2339,11 @@ class ResetTest(unittest.TestCase):
     self.assertFalse(mock_obj._replay_mode)
     mock_obj._Replay()
     self.assertTrue(mock_obj._replay_mode)
-    self.assertEquals(1, len(mock_obj._expected_calls_queue))
+    self.assertEqual(1, len(mock_obj._expected_calls_queue))
 
     mox.Reset(mock_obj)
     self.assertFalse(mock_obj._replay_mode)
-    self.assertEquals(0, len(mock_obj._expected_calls_queue))
+    self.assertEqual(0, len(mock_obj._expected_calls_queue))
 
 
 class MyTestCase(unittest.TestCase):
@@ -2356,7 +2356,7 @@ class MyTestCase(unittest.TestCase):
 
   def testMethodOverride(self):
     """Should be properly overriden in a derived class."""
-    self.assertEquals(42, self.another_critical_variable)
+    self.assertEqual(42, self.another_critical_variable)
     self.another_critical_variable += 1
 
 
@@ -2369,15 +2369,15 @@ class MoxTestBaseMultipleInheritanceTest(mox.MoxTestBase, MyTestCase):
 
   def testMultipleInheritance(self):
     """Should be able to access members created by all parent setUp()."""
-    self.assert_(isinstance(self.mox, mox.Mox))
-    self.assertEquals(42, self.critical_variable)
+    self.assertTrue(isinstance(self.mox, mox.Mox))
+    self.assertEqual(42, self.critical_variable)
 
   def testMethodOverride(self):
     """Should run before MyTestCase.testMethodOverride."""
-    self.assertEquals(99, self.another_critical_variable)
+    self.assertEqual(99, self.another_critical_variable)
     self.another_critical_variable = 42
     super(MoxTestBaseMultipleInheritanceTest, self).testMethodOverride()
-    self.assertEquals(43, self.another_critical_variable)
+    self.assertEqual(43, self.another_critical_variable)
 
 class MoxTestDontMockProperties(MoxTestBaseTest):
     def testPropertiesArentMocked(self):


### PR DESCRIPTION
This is to avoid the deprecation warnings that tox shows when running tests
